### PR TITLE
Untracked minor transfer history improvements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -343,7 +343,6 @@ form {
 /* End styles for Balance Inquiry */
 
 /* Start styles for Transfer History */
-
 .transfers-container {
   margin: 20px;
   height: 65vh;
@@ -357,9 +356,9 @@ form {
 
 .sent-transfers, .received-transfers, .transfers-headers {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  grid-column-gap: 10px;
-  grid-row-gap: 10px;
+  grid-template-columns: repeat(3, 1fr);
+  grid-column-gap: 4px;
+  grid-row-gap: 4px;
   }
 
   .transfers-headers p {

--- a/src/components/TransferCard.jsx
+++ b/src/components/TransferCard.jsx
@@ -1,9 +1,13 @@
-import { parseISO, format } from 'date-fns';
+import { parseISO, formatDistanceToNow } from 'date-fns';
 
-export default function TransferCard({ date, sender, receiver, amount }){
+
+export default function TransferCard({ date, target, amount }) {
     const formatDate = (unformattedDate) => {
         const formattedDate = parseISO(unformattedDate);
-        return format(formattedDate, "MMMM do, yyyy, hh:mma");
+        return formatDistanceToNow(
+            formattedDate,
+            { addSuffix: true }
+        );          
     }
 
     return (
@@ -12,13 +16,10 @@ export default function TransferCard({ date, sender, receiver, amount }){
                 <p>{formatDate(date)}</p>
             </div>
             <div>
-                <p>{sender}</p>
+                <p>{target}</p>
             </div>
             <div>
-                <p>{receiver}</p>
-            </div>
-            <div>
-                <p>{amount} Sirch Coins</p>
+                <p>{amount}</p>
             </div>
         </>
     )

--- a/src/components/TransferCard.jsx
+++ b/src/components/TransferCard.jsx
@@ -2,25 +2,25 @@ import { parseISO, formatDistanceToNow } from 'date-fns';
 
 
 export default function TransferCard({ date, target, amount }) {
-    const formatDate = (unformattedDate) => {
-        const formattedDate = parseISO(unformattedDate);
-        return formatDistanceToNow(
-            formattedDate,
-            { addSuffix: true }
-        );          
-    }
+  const formatDate = (unformattedDate) => {
+    const parsedDate = parseISO(unformattedDate);
+    return formatDistanceToNow(
+      parsedDate,
+      { addSuffix: true }
+    );          
+  };
 
-    return (
-        <>
-            <div>
-                <p>{formatDate(date)}</p>
-            </div>
-            <div>
-                <p>{target}</p>
-            </div>
-            <div>
-                <p>{amount}</p>
-            </div>
-        </>
-    )
+  return (
+    <>
+      <div>
+        <p>{formatDate(date)}</p>
+      </div>
+      <div>
+        <p>{target}</p>
+      </div>
+      <div>
+        <p>{amount}</p>
+      </div>
+    </>
+  );
 }

--- a/src/components/Transfers.jsx
+++ b/src/components/Transfers.jsx
@@ -90,16 +90,12 @@ export default function Transfers() {
   return (
     <>
       <h3 className="page-header">Transfer History</h3>
-      <h2 className="transfers-header">
-          Your transfers:
-        </h2>
       <div className="transfers-container">
 
-        <h3>Sent Transfers</h3>
+        <h3>Sent</h3>
         <div className="transfers-headers">
-          <p>Date Sent</p>
-          <p>Sender</p>
-          <p>Receiver</p>
+          <p>Date</p>
+          <p>To</p>
           <p>Amount</p>
         </div>
         <div className="sent-transfers">
@@ -108,29 +104,28 @@ export default function Transfers() {
               <TransferCard 
                 key={transfer.id}
                 date={transfer.created_at}
-                sender={transfer.sender?.user?.email || transfer.sender_id}
-                receiver={transfer.receiver?.user?.email || transfer.receiver_id}
-                amount={transfer.amount} />
-          ))) : 
+                target={transfer.receiver?.user?.email || transfer.receiver_id}
+                amount={transfer.amount}
+              />
+          ))) :
           <p>Loading...</p>} 
         </div>
         
-        <h3>Received Transfers</h3>
+        <h3>Received</h3>
         <div className="transfers-headers">
-          <p>Date Sent</p>
-          <p>Sender</p>
-          <p>Receiver</p>
+          <p>Date</p>
+          <p>From</p>
           <p>Amount</p>
         </div>
         <div className="received-transfers">
           { userReceivedTransfers ? (
             userReceivedTransfers.map((transfer) => (
-              <TransferCard 
+              <TransferCard
                 key={transfer.id}
                 date={transfer.created_at}
-                sender={transfer.sender?.user?.email || transfer.sender_id}
-                receiver={transfer.receiver?.user?.email || transfer.receiver_id}
-                amount={transfer.amount} />
+                target={transfer.sender?.user?.email || transfer.sender_id}
+                amount={transfer.amount}
+              />
           ))) : 
           <p>Loading...</p>} 
         </div>

--- a/src/components/Transfers.jsx
+++ b/src/components/Transfers.jsx
@@ -92,7 +92,7 @@ export default function Transfers() {
       <h3 className="page-header">Transfer History</h3>
       <div className="transfers-container">
 
-        <h3>Sent</h3>
+        <h3>Sent by Me</h3>
         <div className="transfers-headers">
           <p>Date</p>
           <p>To</p>
@@ -111,7 +111,7 @@ export default function Transfers() {
           <p>Loading...</p>} 
         </div>
         
-        <h3>Received</h3>
+        <h3>Received by Me</h3>
         <div className="transfers-headers">
           <p>Date</p>
           <p>From</p>

--- a/src/components/Transfers.jsx
+++ b/src/components/Transfers.jsx
@@ -96,7 +96,7 @@ export default function Transfers() {
         <div className="transfers-headers">
           <p>Date</p>
           <p>To</p>
-          <p>Amount</p>
+          <p>Sirch Coins (SC)</p>
         </div>
         <div className="sent-transfers">
           { userSentTransfers ? (
@@ -110,12 +110,12 @@ export default function Transfers() {
           ))) :
           <p>Loading...</p>} 
         </div>
-        
+        <br></br>
         <h3>Received by Me</h3>
         <div className="transfers-headers">
           <p>Date</p>
           <p>From</p>
-          <p>Amount</p>
+          <p>Sirch Coins (SC)</p>
         </div>
         <div className="received-transfers">
           { userReceivedTransfers ? (


### PR DESCRIPTION
Simplifies (dumbs down) the Transfer History page a bit until we get around to bigger changes:

- hides the "Sender" or "Receiver" column relative to the user, so they don't see their email addresses repeated a bunch of times
- switched to a more user-friendly date format for now
- minor label, style, and rendering changes

TODO (Linear tasks will be created for these):
- establish a currency symbol and/or abbreviation to denote Sirch Coin currency (SC for now)
- convert all this back to a "transactions" history where the Sent and Received line items would interleave in a single list view
- add transaction "types" and "memos" facilities to the schema and views, so the system can mark what the transaction is ("deposit", "user transfer", "purchase" or whatever), and allow users to annotate *why* they are sending coins, or for the system to track details of each transaction (like stripe transaction ids, purchase vendor ids, etc.)
- add views, tooltips, or whatnot to allow the user to drill down into a transaction to see more details (actual date, etc)