### PR TITLE
Sirco 118: Stripe Bug Fixes 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -193,6 +193,13 @@ button.danger{
     margin:2rem;
 }
 
+.coin-amount-input{
+  max-width: 40%;
+  border: 2px solid black;
+  font-size:xx-large;
+  margin-bottom: 10px;
+}
+
 
 /* Styles for the success message */
 .success {

--- a/src/App.css
+++ b/src/App.css
@@ -200,6 +200,10 @@ button.danger{
   margin-bottom: 10px;
 }
 
+.sirch-symbol-large{
+  font-size: xx-large;
+  padding-right: 10px;
+}
 
 /* Styles for the success message */
 .success {

--- a/src/components/Purchase.jsx
+++ b/src/components/Purchase.jsx
@@ -86,6 +86,7 @@ export default function Purchase() {
           <p>Current cost per coin: ${Number(pricePerCoin).toFixed(2)} </p>
           }
         <p>Currency: {currency.toUpperCase()}</p>
+        <span className="sirch-symbol-large">ⓢ</span>
         <input
           className="coin-amount-input"
           type="number"

--- a/src/components/Purchase.jsx
+++ b/src/components/Purchase.jsx
@@ -55,9 +55,11 @@ export default function Purchase() {
       <div>
         <h2>Purchase Sirch Coins</h2>
         <h3>How many Sirch Coins would you like to purchase?</h3>
-        {/* TODO: Fix NaN on load */}
         {/* TODO: Format for other currencies if we decide to accept them in the future */}
-        <p>Current cost per coin: ${Number(pricePerCoin).toFixed(2)} </p>
+        { pricePerCoin === "Loading..." ? 
+          <p>Current cost per coin: {pricePerCoin} </p> : 
+          <p>Current cost per coin: ${Number(pricePerCoin).toFixed(2)} </p>
+          }
         <p>Currency: {currency.toUpperCase()}</p>
         <input
           type="number"

--- a/src/components/Purchase.jsx
+++ b/src/components/Purchase.jsx
@@ -12,6 +12,7 @@ export default function Purchase() {
   const [stripePromise, setStripePromise] = useState(null);
   const [clientSecret, setClientSecret] = useState("");
   const [coinAmount, setCoinAmount] = useState(5);
+  const [coinAmountError, setCoinAmountError] = useState(false);
   const [pricePerCoin, setPricePerCoin] = useState("Loading...");
   const [totalPrice, setTotalPrice] = useState("Loading...");
   const [currency, setCurrency] = useState("Loading...");
@@ -50,6 +51,30 @@ export default function Purchase() {
     stripeCreatePaymentIntent();
   }, [userInTable, coinAmount])
 
+  // TODO: Update this logic once Sirch Coins discount period expires (e.g. users can purchase 1 Sirch Coin for $1)
+  const handleAmountChange = (e) => {
+    const value = e.target.value;
+    
+    if (value === '') {
+      setCoinAmount('');
+      setCoinAmountError(false);
+      return;
+    }
+
+    const numValue = parseInt(value, 10);
+    if (!isNaN(numValue)) {
+      setCoinAmount(value);
+      setCoinAmountError(numValue < 5);
+    }
+  };
+
+  const handleBlur = () => {
+    if (coinAmount !== '' && parseInt(coinAmount, 10) < 5) {
+      setCoinAmount('5');
+      setCoinAmountError(false);
+    }
+  };
+
   return (
     <div className="purchase-container">
       <div>
@@ -62,16 +87,19 @@ export default function Purchase() {
           }
         <p>Currency: {currency.toUpperCase()}</p>
         <input
+          className="coin-amount-input"
           type="number"
           name="coins"
           placeholder="Enter the number of coins you want to purchase"
           value= {coinAmount}
-          onChange={(e) => setCoinAmount(e.target.value)}
-          // TODO: Fix to not allow user to change below 5 (breaks paymentIntent)
+          onChange={handleAmountChange}
+          onBlur={handleBlur}
           min="5"
           required
         >
         </input>
+        <p><strong>Note: At the current time, a minimum purchase of 5 Sirch Coins is required.</strong></p>
+        {/* TODO: Add "See more" link with info on Stripe/purchasing */}
         <p>Sirch Coins uses the payment provider Stripe for secure transactions. See more...</p>
         <h4>Your total price: ${totalPrice}</h4>
       </div>

--- a/src/components/Purchase.jsx
+++ b/src/components/Purchase.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext, useMemo } from "react";
 import { loadStripe } from "@stripe/stripe-js";
 import { Elements } from "@stripe/react-stripe-js";
 import { Link } from "react-router-dom";
@@ -17,6 +17,7 @@ export default function Purchase() {
   const [totalPrice, setTotalPrice] = useState("Loading...");
   const [currency, setCurrency] = useState("Loading...");
   const { userInTable } = useContext(AuthContext);
+  const options = useMemo(() => ({clientSecret}), [clientSecret])
 
   useEffect(() => {
     setStripePromise(loadStripe(import.meta.env.VITE_STRIPE_TEST_PUBLISHABLE_KEY))
@@ -41,7 +42,6 @@ export default function Purchase() {
       } else if (error instanceof FunctionsFetchError) {
         console.log('Fetch error: ', error.message);
       } else {
-        console.log("Data: ", data);
         setClientSecret(data.clientSecret);
         setPricePerCoin(data.pricePerCoin);
         setTotalPrice(data.totalAmount);
@@ -108,7 +108,11 @@ export default function Purchase() {
           
         {/* TODO: Fix remounting of Elements - clientSecret cannot change */}
         {stripePromise && clientSecret && 
-         <Elements stripe={stripePromise} options={{clientSecret}}>
+         <Elements 
+          key={clientSecret}
+          stripe={stripePromise} 
+          options={options}
+         >
           <CheckoutForm/>
          </Elements>}
       </div>


### PR DESCRIPTION
This update introduces some bug fixes related to the initial stripe integration, from SIRCO-118 in Linear. This update does not yet include fixes to useEffect/ensuring that every keystroke does not initiate a `paymentIntent`. Here’s what should be fixed:

* Forces all inputs to be > 5 due to the current “discounted” price and Stripes 0.50 limit. 
* Fixes an issue where certain numbers had a ton of decimal places (now fixed to 2 decimal places for the `pricePerCoin` and the `totalPrice`. 
* Fixes an issue where `pricePerCoin` displayed as NaN on initial load. 
* Fixes a key issue where the `clientSecret` prop was changing due to the useEffect / coinAmount - added key = {clientSecret} and memoized clientSecret for performance. The downside of this is that the payment box re-renders every time you change the amount of coins you want to buy (at least it happens pretty quickly?)

Here is one issue that is NOT yet resolved, and is going to be added to SIRCO-116 – useEffect Cleanup. Please test this scenario, and let me know if you have any ideas of why this is happening/if this is potentially in any way related to the backend paymentIntent?

How to reproduce:
* Navigate to the Purchase page after logging in 
* Type a “0” into the input box so that the amount of coins you want to buy is “50”, and confirm the total price is $5
* Delete the “0” and type in “1” so that the total you want to buy is “51” - then confirm that the total price is broken, in that it does not update to $5.10 - see console error 
* Delete the “1” and replace with a “2” so that the total coins is “52” and confirm the price is working again 
^^^ I’ve tried this with other numbers, like 60, 61, 62, etc - and the “1” is not always the issue, which is why I’m very confused as to what’s happening here, even with a timing delay using setTimeout. Any thoughts? 