### PR TITLE
SIRCO-116: Limit Calls for createPaymentIntent and Force Integer Values in Input 

### DIFF
--- a/src/components/Purchase.jsx
+++ b/src/components/Purchase.jsx
@@ -38,8 +38,14 @@ export default function Purchase() {
         }
       });
   
-      if (error) {
-        console.error('Error loading initial data:', error);
+      // TODO: Handle error messaging for user
+      if (error instanceof FunctionsHttpError) {
+        const errorMessage = await error.context.json();
+        console.log('Function returned an error: ', errorMessage);
+      } else if (error instanceof FunctionsRelayError) {
+        console.log('Relay error: ', error.message);
+      } else if (error instanceof FunctionsFetchError) {
+        console.log('Fetch error: ', error.message);
       } else {
         console.log("Data:", data);
         setClientSecret(data.clientSecret);
@@ -63,10 +69,14 @@ export default function Purchase() {
       }
     });
 
-    if (error){
-      // TODO: Handle error to user
-      console.error('Error creating payment intent: ', error);
-      alert("There was an error initiating your payment: ", error)
+    // TODO: Handle error messaging for user
+    if (error instanceof FunctionsHttpError) {
+      const errorMessage = await error.context.json();
+      console.log('Function returned an error: ', errorMessage);
+    } else if (error instanceof FunctionsRelayError) {
+      console.log('Relay error: ', error.message);
+    } else if (error instanceof FunctionsFetchError) {
+      console.log('Fetch error: ', error.message);
     } else {
       setClientSecret(data.clientSecret);
       setCoinAmount(localCoinAmount);

--- a/src/components/Purchase.jsx
+++ b/src/components/Purchase.jsx
@@ -74,8 +74,6 @@ export default function Purchase() {
     }
   }
 
-
-
   // TODO: Update this logic once Sirch Coins discount period expires (e.g. users can purchase 1 Sirch Coin for $1)
   const handleAmountChange = (e) => {
     const value = e.target.value;
@@ -87,7 +85,7 @@ export default function Purchase() {
       return;
     }
   
-    const numValue = parseFloat(value);
+    const numValue = parseInt(value, 10);
     if (!isNaN(numValue)) {
       setLocalCoinAmount(numValue);
       setLocalTotalPrice(numValue * parseFloat(pricePerCoin));
@@ -130,6 +128,7 @@ export default function Purchase() {
           onChange={handleAmountChange}
           onBlur={handleBlur}
           min="5"
+          step="1"
           required
         />
         <p><strong>Note: At the current time, a minimum purchase of 5 Sirch Coins is required.</strong></p>

--- a/src/components/Purchase.jsx
+++ b/src/components/Purchase.jsx
@@ -25,6 +25,7 @@ export default function Purchase() {
     setStripePromise(loadStripe(import.meta.env.VITE_STRIPE_TEST_PUBLISHABLE_KEY))
   }, [])
 
+  // TODO: Replace this with a new edge function in supabase instead of creating the payment intent on page load
   useEffect(() => {
     const loadInitialData = async () => {
       if (!userInTable) return;


### PR DESCRIPTION

This update cleans up the number of `paymentIntents` that get created in Stripe, with a couple caveats/callouts for future updates. It also forces whole integer values for the input field.

How this works:
1. On the first load of the page a `paymentIntent` is created which also loads the Stripe `CheckoutForm` modal, for the minimum purchase of 5 coins for $0.50 (more on this below/how to remedy this paymentIntent)
2. Next, a user types in the actual amount they want to purchase and clicks on “Proceed to Payment”
3. This creates a `paymentIntent` and re-renders the `CheckoutForm` for the actual/new amount that they want to buy
4. User fills out form and buys the coins 

Future Update to Avoid Initial paymentIntent creation on page load:
* Create a new edge function in Supabase that only returns the `pricePerCoin`, and replace it with what’s currently in the `loadInitialData` function (creating a paymentIntent). 
* This will ensure that when the page initially loads, the user doesn’t see the Checkout Form and has to click on “Proceed to Payment” before checking out.

Caveats/Considerations
* While the single page layout of this is nice, it may be better to separate the Checkout Form onto a new page or an on-page popup.
* The reason for this is, with the current/future update suggestion, if a user wants to buy 100 coins, but accidentally types in 10 and clicks “Proceed to Payment”, they’ll see the Checkout Form. Realizing their mistake, they might fix the 10 by adding a 0, making it 100, without clicking on the “Proceed to Payment” button again. When they fill out the  Checkout Form, they’re actually still only purchasing 10, instead of 100. 
* Another page/screen for the Checkout Form may remedy this by showing the current amount they’re buying, and if they see the mistake, they go back to the input amount, change the value, then click Proceed to Payment again to see the updated Checkout Form. 
* Finally, I'd assume that by clicking "cancel" or "go back" for the Checkout Form popup or second page, that's where we'd handle cancelling the payment intent 