### PR TITLE
SIRCO-125: Single createPaymentIntent Calls & Transition to price-per-coin edge function 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -193,6 +193,17 @@ button.danger{
     margin:2rem;
 }
 
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5); /* Dark background with 50% opacity */
+  backdrop-filter: blur(5px); /* Blur effect */
+  z-index: 99; /* Just below the popup */
+}
+
 .checkout-form-popup{
   z-index: 100;
   max-width: 90%;

--- a/src/App.css
+++ b/src/App.css
@@ -185,12 +185,25 @@ button.danger{
 /*  Start Styles for Purchase Page */
 
 .purchase-container{
-    display: grid;
+    /* display: grid;
     grid-template-columns: repeat(2, 1fr);
     grid-template-rows: 1fr;
     grid-column-gap: 20px;
-    grid-row-gap: 0px;
+    grid-row-gap: 0px; */
     margin:2rem;
+}
+
+.checkout-form-popup{
+  z-index: 100;
+  max-width: 90%;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: white;
+  padding: 20px;
+  border-radius: 5px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 .coin-amount-input{

--- a/src/App.css
+++ b/src/App.css
@@ -200,7 +200,7 @@ button.danger{
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.5); 
-  backdrop-filter: blur(5px); 
+  backdrop-filter: blur(8px); 
   z-index: 99; 
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -199,9 +199,9 @@ button.danger{
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.5); /* Dark background with 50% opacity */
-  backdrop-filter: blur(5px); /* Blur effect */
-  z-index: 99; /* Just below the popup */
+  background-color: rgba(0, 0, 0, 0.5); 
+  backdrop-filter: blur(5px); 
+  z-index: 99; 
 }
 
 .checkout-form-popup{

--- a/src/components/Purchase.jsx
+++ b/src/components/Purchase.jsx
@@ -18,6 +18,7 @@ export default function Purchase() {
   const [pricePerCoin, setPricePerCoin] = useState("Loading...");
   const [totalPrice, setTotalPrice] = useState("Loading...");
   const [currency, setCurrency] = useState("Loading...");
+  const [showCheckoutForm, setShowCheckoutForm] = useState(false);
   const { userInTable } = useContext(AuthContext);
   const options = useMemo(() => ({clientSecret}), [clientSecret])
 
@@ -82,6 +83,7 @@ export default function Purchase() {
       setCoinAmount(localCoinAmount);
       setTotalPrice(data.totalAmount);
       setCurrency(data.currency);
+      setShowCheckoutForm(true)
     }
   }
 
@@ -125,10 +127,9 @@ export default function Purchase() {
         <h3>How many Sirch Coins would you like to purchase?</h3>
         {/* TODO: Format for other currencies if we decide to accept them in the future */}
         { pricePerCoin === "Loading..." ? 
-          <p>Current cost per coin: {pricePerCoin} </p> : 
-          <p>Current cost per coin: ${formatPrice(pricePerCoin)} </p>
+          <p>Current price per coin: {pricePerCoin} </p> : 
+          <p>Current price per coin: ${formatPrice(pricePerCoin)} </p>
           }
-        <p>Currency: {currency.toUpperCase()}</p>
         <span className="sirch-symbol-large">ⓢ</span>
         <input
           className="coin-amount-input"
@@ -146,8 +147,8 @@ export default function Purchase() {
         {/* TODO: Add "See more" link with info on Stripe/purchasing */}
         <p>Sirch Coins uses the payment provider Stripe for secure transactions. See more...</p>
         { localTotalPrice === 0 ? 
-          <h4>Your total price: {totalPrice}</h4> :
-          <h4>Your total price: ${formatPrice(localTotalPrice)}</h4>
+          <h4>Your total price: {totalPrice} {currency.toUpperCase()}</h4> :
+          <h4>Your total price: ${formatPrice(localTotalPrice)} {currency.toUpperCase()}</h4>
         }
         <button 
           onClick={createPaymentIntent} 
@@ -157,16 +158,17 @@ export default function Purchase() {
         </button>
       </div>
       <div>
-          
         {/* TODO: Fix remounting of Elements - clientSecret cannot change */}
-        {stripePromise && clientSecret && 
+        {stripePromise && clientSecret && showCheckoutForm &&
+        <dialog open className="checkout-form-popup">
          <Elements 
           key={clientSecret}
           stripe={stripePromise} 
           options={options}
          >
           <CheckoutForm/>
-         </Elements>}
+         </Elements>
+         </dialog>}
       </div>
       <div className="bottom-btn-container">
         <Link to="/" className="big-btn-red">

--- a/src/components/Purchase.jsx
+++ b/src/components/Purchase.jsx
@@ -156,16 +156,22 @@ export default function Purchase() {
       </div>
       <div>
         {/* TODO: Fix remounting of Elements - clientSecret cannot change */}
-        {stripePromise && clientSecret && showCheckoutForm &&
-        <dialog open className="checkout-form-popup">
-         <Elements 
-          key={clientSecret}
-          stripe={stripePromise} 
-          options={options}
-         >
-          <CheckoutForm coinAmount={coinAmount} totalPrice={totalPrice}/>
-         </Elements>
-         </dialog>}
+        <div>
+          {stripePromise && clientSecret && showCheckoutForm && (
+            <>
+              <div className="overlay"></div>
+              <dialog open className="checkout-form-popup">
+                <Elements 
+                  key={clientSecret}
+                  stripe={stripePromise} 
+                  options={options}
+                >
+                  <CheckoutForm coinAmount={coinAmount} totalPrice={totalPrice} setShowCheckoutForm={setShowCheckoutForm}/>
+                </Elements>
+              </dialog>
+            </>
+          )}
+        </div>
       </div>
       <div className="bottom-btn-container">
         <Link to="/" className="big-btn-red">

--- a/src/components/Purchase.jsx
+++ b/src/components/Purchase.jsx
@@ -31,10 +31,8 @@ export default function Purchase() {
     const loadInitialData = async () => {
       if (!userInTable) return;
   
-      const { data, error } = await supabase.functions.invoke('stripe-create-payment-intent', {
+      const { data, error } = await supabase.functions.invoke('price-per-coin', {
         body: {
-          userId: userInTable?.user_id,
-          email: userInTable?.email,
           numberOfCoins: 5  
         }
       });
@@ -49,7 +47,6 @@ export default function Purchase() {
         console.log('Fetch error: ', error.message);
       } else {
         console.log("Data:", data);
-        setClientSecret(data.clientSecret);
         setPricePerCoin(data.pricePerCoin);
         setLocalTotalPrice(data.totalAmount);
         setCurrency(data.currency);
@@ -80,7 +77,7 @@ export default function Purchase() {
       console.log('Fetch error: ', error.message);
     } else {
       setClientSecret(data.clientSecret);
-      setCoinAmount(localCoinAmount);
+      setCoinAmount(data.numberOfCoins);
       setTotalPrice(data.totalAmount);
       setCurrency(data.currency);
       setShowCheckoutForm(true)
@@ -166,7 +163,7 @@ export default function Purchase() {
           stripe={stripePromise} 
           options={options}
          >
-          <CheckoutForm/>
+          <CheckoutForm coinAmount={coinAmount} totalPrice={totalPrice}/>
          </Elements>
          </dialog>}
       </div>

--- a/src/components/Stripe/CheckoutForm.jsx
+++ b/src/components/Stripe/CheckoutForm.jsx
@@ -46,6 +46,8 @@ export default function CheckoutForm({coinAmount, totalPrice, setShowCheckoutFor
   return (
     <>
     <h3>You&apos;re purchasing: <br></br>{coinAmount} coins for a total of ${totalPrice}</h3>
+    {/* TODO: Update this line with final timeout decision for price and update Purchase.jsx accordingly */}
+    <p><em>This price is locked in for the next 15 minutes. After that time, you may need to refresh and try again.</em></p>
     <form id="payment-form" onSubmit={handleSubmit}>
       <PaymentElement id="payment-element" />
       <button disabled={isProcessing || !stripe || !elements} id="submit">
@@ -57,8 +59,6 @@ export default function CheckoutForm({coinAmount, totalPrice, setShowCheckoutFor
       <button onClick={handleCancelPaymentIntent}>
         Cancel
       </button>
-      {/* TODO: Update this line with final timeout decision for price and update Purchase.jsx accordingly */}
-      <p><em>This price is locked in for the next 15 minutes. After that time, you may need to refresh and try again.</em></p>
       {/* Show any error or success messages */}
       {message && <div id="payment-message">{message}</div>}
     </form>

--- a/src/components/Stripe/CheckoutForm.jsx
+++ b/src/components/Stripe/CheckoutForm.jsx
@@ -2,7 +2,7 @@ import { PaymentElement } from "@stripe/react-stripe-js";
 import { useState } from "react";
 import { useStripe, useElements } from "@stripe/react-stripe-js";
 
-export default function CheckoutForm({coinAmount, totalPrice}) {
+export default function CheckoutForm({coinAmount, totalPrice, setShowCheckoutForm}) {
   const stripe = useStripe();
   const elements = useElements();
 
@@ -37,9 +37,10 @@ export default function CheckoutForm({coinAmount, totalPrice}) {
   };
 
   // TODO: Replace with supabase function to cancel payment intent
-  // const handleCancelPaymentIntent = async () => {
-  //   console.log("Replace this with the cancel payment intent supabase edge function")
-  // }
+  const handleCancelPaymentIntent = async () => {
+    setShowCheckoutForm(false)
+    console.log("Replace this with the cancel payment intent supabase edge function")
+  }
 
   return (
     <>
@@ -52,7 +53,7 @@ export default function CheckoutForm({coinAmount, totalPrice}) {
         </span>
       </button>
       {/* TODO: add onClick handleCancelPaymentIntent */}
-      <button>
+      <button onClick={handleCancelPaymentIntent}>
         Cancel
       </button>
       {/* Show any error or success messages */}

--- a/src/components/Stripe/CheckoutForm.jsx
+++ b/src/components/Stripe/CheckoutForm.jsx
@@ -36,6 +36,11 @@ export default function CheckoutForm() {
     setIsProcessing(false);
   };
 
+  // TODO: Replace with supabase function to cancel payment intent
+  // const handleCancelPaymentIntent = async () => {
+  //   console.log("Replace this with the cancel payment intent supabase edge function")
+  // }
+
   return (
     <form id="payment-form" onSubmit={handleSubmit}>
       <PaymentElement id="payment-element" />
@@ -43,6 +48,10 @@ export default function CheckoutForm() {
         <span id="button-text">
           {isProcessing ? "Processing ... " : "Buy Sirch Coins"}
         </span>
+      </button>
+      {/* TODO: add onClick handleCancelPaymentIntent */}
+      <button>
+        Cancel
       </button>
       {/* Show any error or success messages */}
       {message && <div id="payment-message">{message}</div>}

--- a/src/components/Stripe/CheckoutForm.jsx
+++ b/src/components/Stripe/CheckoutForm.jsx
@@ -2,7 +2,7 @@ import { PaymentElement } from "@stripe/react-stripe-js";
 import { useState } from "react";
 import { useStripe, useElements } from "@stripe/react-stripe-js";
 
-export default function CheckoutForm() {
+export default function CheckoutForm({coinAmount, totalPrice}) {
   const stripe = useStripe();
   const elements = useElements();
 
@@ -42,6 +42,8 @@ export default function CheckoutForm() {
   // }
 
   return (
+    <>
+    <h3>You&apos;re purchasing: <br></br>{coinAmount} coins for a total of ${totalPrice}</h3>
     <form id="payment-form" onSubmit={handleSubmit}>
       <PaymentElement id="payment-element" />
       <button disabled={isProcessing || !stripe || !elements} id="submit">
@@ -56,5 +58,6 @@ export default function CheckoutForm() {
       {/* Show any error or success messages */}
       {message && <div id="payment-message">{message}</div>}
     </form>
+    </>
   );
 }

--- a/src/components/Stripe/CheckoutForm.jsx
+++ b/src/components/Stripe/CheckoutForm.jsx
@@ -2,6 +2,7 @@ import { PaymentElement } from "@stripe/react-stripe-js";
 import { useState } from "react";
 import { useStripe, useElements } from "@stripe/react-stripe-js";
 
+// eslint-disable-next-line react/prop-types
 export default function CheckoutForm({coinAmount, totalPrice, setShowCheckoutForm}) {
   const stripe = useStripe();
   const elements = useElements();

--- a/src/components/Stripe/CheckoutForm.jsx
+++ b/src/components/Stripe/CheckoutForm.jsx
@@ -57,6 +57,8 @@ export default function CheckoutForm({coinAmount, totalPrice, setShowCheckoutFor
       <button onClick={handleCancelPaymentIntent}>
         Cancel
       </button>
+      {/* TODO: Update this line with final timeout decision for price and update Purchase.jsx accordingly */}
+      <p><em>This price is locked in for the next 15 minutes. After that time, you may need to refresh and try again.</em></p>
       {/* Show any error or success messages */}
       {message && <div id="payment-message">{message}</div>}
     </form>


### PR DESCRIPTION
This update introduces the new “price-per-coin” function from supabase and uses that to handle the initial data load. This also creates a new popup form for the payment intent / Checkout Form, which has some placeholder copy regarding price guarantees and the ability to cancel a paymentIntent (for now, just closes the popup - see code comments).

This also includes the removal of an individual “currency” line item and adds that as an addendum to the total price. Changes frontend copy of "cost per coin" to "price per coin"

Caveat: it takes about 2 seconds for the popup to show... will look into this in future updates