### PR TITLE
Transactions: Adding more details

### DIFF
--- a/src/components/TransactionHistory/TransactionCard.jsx
+++ b/src/components/TransactionHistory/TransactionCard.jsx
@@ -1,7 +1,7 @@
 import { parseISO, formatDistanceToNow } from 'date-fns';
 
 // eslint-disable-next-line react/prop-types
-export default function TransactionCard({ id, date, type, amount, status }) {
+export default function TransactionCard({ date, type, amount, status, details }) {
   const formatDate = (unformattedDate) => {
     const parsedDate = parseISO(unformattedDate);
     return formatDistanceToNow(
@@ -25,7 +25,7 @@ export default function TransactionCard({ id, date, type, amount, status }) {
         <p>{status}</p>
       </div>
       <div>
-        <p>{id}</p>
+        <p>{details}</p>
       </div>
     </>
   );

--- a/src/components/TransactionHistory/Transactions.jsx
+++ b/src/components/TransactionHistory/Transactions.jsx
@@ -43,6 +43,21 @@ export default function Transactions() {
     }
   }, [userInTable]);
 
+
+  const getTransactionDetails = (transaction) => {
+    switch (transaction.type) {
+      case 'SENT':
+      case 'RECEIVED':
+        return `Memo: ${transaction.details.email || ''}`;
+      case 'PURCHASE':
+        return `Payment Intent ID: ${transaction.details.paymentIntentId || ''}`;
+      case 'INITIAL BALANCE':
+        return 'Welcome!';
+      default:
+        return ``;
+    }
+  };
+  
   return (
     <>
       <h2>Transaction History</h2>
@@ -60,12 +75,13 @@ export default function Transactions() {
                 userTransactions.map((userTransaction) => (
                   <TransactionCard 
                     key={userTransaction.id}
-                    id={userTransaction.id}
                     date={userTransaction.created_at}
                     type={userTransaction.type}
                     amount={userTransaction.amount}
                     status={userTransaction.status}
+                    details={getTransactionDetails(userTransaction)} 
                   />
+                  
                 ))
               )
             :

--- a/src/components/TransactionHistory/Transactions.jsx
+++ b/src/components/TransactionHistory/Transactions.jsx
@@ -48,7 +48,7 @@ export default function Transactions() {
     switch (transaction.type) {
       case 'SENT':
       case 'RECEIVED':
-        return `Memo: ${transaction.details.email || ''}`;
+        return `Memo: ${transaction.details.memo || ''}`;
       case 'PURCHASE':
         return `Payment Intent ID: ${transaction.details.paymentIntentId || ''}`;
       case 'INITIAL BALANCE':


### PR DESCRIPTION
On SENT and RECEIVED transaction rows: render the "Memo" data in the Details column, maybe with the "to_user" and "from_user" details

On PURCHASE transactions rows: render the Stripe "payment intent id" and maybe the "receipt" link

On INITIAL_BALANCE transaction rows: maybe render nothing, or just the word "Welcome!"